### PR TITLE
Add insert shortcut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "leadr"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "clap",
  "confy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leadr"
 description = "Shell aliases on steroids"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 authors = ["ll-nick"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Here's an overview of the shortcut types that can be configured:
 | Type | Description | Cursor Position |
 | ---- | ----------- | ---------------- |
 | `Execute` (Default) | Execute the command right away | N/A |
+| `Insert` | Inserts the command at the current cursor position | At the end of the inserted command |
 | `Replace` | Sets your current prompt to the command | At the end of the command unless `#CURSOR` is specified |
 | `Prepend` | Prepend the command to your current prompt | Where it was before adding the prefix |
 | `Append` | Append the command to your current prompt | At the end of the command |

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -2,6 +2,7 @@
 LEADR_BIND_KEY='{{bind_key}}'
 LEADR_CURSOR_POSITION_ENCODING='{{cursor_position_encoding}}'
 LEADR_EXEC_PREFIX='{{exec_prefix}}'
+LEADR_INSERT_PREFIX='{{insert_prefix}}'
 LEADR_PREPEND_PREFIX='{{prepend_prefix}}'
 LEADR_APPEND_PREFIX='{{append_prefix}}'
 
@@ -31,6 +32,14 @@ __leadr_invoke__() {
             history -s "$actual_cmd"
             eval "$actual_cmd"
         fi
+        return
+    fi
+
+    if [[ "$cmd" =~ ^${LEADR_INSERT_PREFIX}\ (.*) ]]; then
+        local to_insert="${BASH_REMATCH[1]}"
+        local original_point=$READLINE_POINT
+        READLINE_LINE="${READLINE_LINE:0:original_point}${to_insert}${READLINE_LINE:original_point}"
+        READLINE_POINT=$((original_point + ${#to_insert}))
         return
     fi
 

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -2,6 +2,7 @@
 LEADR_BIND_KEY='{{bind_key}}'
 LEADR_CURSOR_POSITION_ENCODING='{{cursor_position_encoding}}'
 LEADR_EXEC_PREFIX='{{exec_prefix}}'
+LEADR_INSERT_PREFIX='{{insert_prefix}}'
 LEADR_PREPEND_PREFIX='{{prepend_prefix}}'
 LEADR_APPEND_PREFIX='{{append_prefix}}'
 
@@ -32,6 +33,13 @@ __leadr_invoke__() {
             print -s -- "$actual_cmd"
             eval "$actual_cmd"
         fi
+        zle reset-prompt
+        return
+    fi
+
+    if [[ "$cmd" =~ "^${LEADR_INSERT_PREFIX} (.*)" ]]; then
+        local to_insert=$match[1]
+        LBUFFER="${LBUFFER}${to_insert}"
         zle reset-prompt
         return
     fi

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use crate::types::{Shortcut, ShortcutType};
 pub struct EncodingStrings {
     pub cursor_position: String,
     pub exec_prefix: String,
+    pub insert_prefix: String,
     pub append_prefix: String,
     pub prepend_prefix: String,
 }
@@ -18,6 +19,7 @@ impl Default for EncodingStrings {
         Self {
             cursor_position: "#CURSOR".into(),
             exec_prefix: "#EXEC".into(),
+            insert_prefix: "#INSERT".into(),
             append_prefix: "#APPEND".into(),
             prepend_prefix: "#PREPEND".into(),
         }
@@ -178,8 +180,9 @@ mod tests {
     fn test_config_defaults() {
         let config = Config::default();
         assert_eq!(config.leadr_key, "<C-g>");
-        assert_eq!(config.encoding_strings.exec_prefix, "#EXEC");
         assert_eq!(config.encoding_strings.cursor_position, "#CURSOR");
+        assert_eq!(config.encoding_strings.exec_prefix, "#EXEC");
+        assert_eq!(config.encoding_strings.insert_prefix, "#INSERT");
         assert_eq!(config.encoding_strings.append_prefix, "#APPEND");
         assert_eq!(config.encoding_strings.prepend_prefix, "#PREPEND");
         assert!(!config.print_sequence);

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -37,6 +37,10 @@ pub fn init_zsh(config: &Config) -> Result<String, LeadrError> {
         )
         .replace("{{exec_prefix}}", &config.encoding_strings.exec_prefix)
         .replace(
+            "{{insert_prefix}}",
+            &config.encoding_strings.insert_prefix,
+        )
+        .replace(
             "{{prepend_prefix}}",
             &config.encoding_strings.prepend_prefix,
         )
@@ -66,6 +70,7 @@ mod tests {
         let result = init_zsh(&config).unwrap();
         assert!(result.contains(&config.encoding_strings.cursor_position));
         assert!(result.contains(&config.encoding_strings.exec_prefix));
+        assert!(result.contains(&config.encoding_strings.insert_prefix));
         assert!(result.contains(&config.encoding_strings.prepend_prefix));
         assert!(result.contains(&config.encoding_strings.append_prefix));
         assert!(result.contains("\\x07"));

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -15,6 +15,10 @@ pub fn init_bash(config: &Config) -> Result<String, LeadrError> {
         )
         .replace("{{exec_prefix}}", &config.encoding_strings.exec_prefix)
         .replace(
+            "{{insert_prefix}}",
+            &config.encoding_strings.insert_prefix,
+        )
+        .replace(
             "{{prepend_prefix}}",
             &config.encoding_strings.prepend_prefix,
         )
@@ -50,6 +54,7 @@ mod tests {
         let result = init_bash(&config).unwrap();
         assert!(result.contains(&config.encoding_strings.cursor_position));
         assert!(result.contains(&config.encoding_strings.exec_prefix));
+        assert!(result.contains(&config.encoding_strings.insert_prefix));
         assert!(result.contains(&config.encoding_strings.prepend_prefix));
         assert!(result.contains(&config.encoding_strings.append_prefix));
         assert!(result.contains("\\x07"));

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,9 @@ pub enum ShortcutType {
     #[default]
     Execute,
 
+    /// A shortcut that is inserted into the command line at the current cursor position.
+    Insert,
+
     /// A shortcut that is inserted into the command line, replacing existing text.
     Replace,
 
@@ -38,6 +41,7 @@ impl Shortcut {
     pub fn format_command(&self, encoding_strings: &EncodingStrings) -> String {
         match self.shortcut_type {
             ShortcutType::Execute => format!("{} {}", encoding_strings.exec_prefix, self.command),
+            ShortcutType::Insert => format!("{} {}", encoding_strings.insert_prefix, self.command),
             ShortcutType::Replace => self.command.to_string(),
             ShortcutType::Prepend => {
                 format!("{} {}", encoding_strings.prepend_prefix, self.command)
@@ -66,6 +70,17 @@ mod tests {
         };
         let encoding_strings = EncodingStrings::default();
         assert_eq!(sc.format_command(&encoding_strings), "#EXEC ls -la");
+    }
+
+    #[test]
+    fn test_format_command_insert() {
+        let sc = Shortcut {
+            command: "echo Hello".into(),
+            description: Some("Print a message".into()),
+            shortcut_type: ShortcutType::Insert,
+        };
+        let encoding_strings = EncodingStrings::default();
+        assert_eq!(sc.format_command(&encoding_strings), "#INSERT echo Hello");
     }
 
     #[test]


### PR DESCRIPTION
This adds a new shortcut type: Insert a command at the current cursor position.