### PR TITLE
Sort --list alphabetically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "leadr"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "confy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leadr"
 description = "Shell aliases on steroids"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 license = "MIT"
 authors = ["ll-nick"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,7 @@ impl Default for Config {
                 evaluate: true,
                 execute: false,
             },
-        );  
+        );
         shortcuts.insert(
             // Prepend Sudo
             "ps".into(),
@@ -147,7 +147,9 @@ impl Config {
 
         // Make sure that "Surround" type shortcuts contain "#COMMAND" in their command
         for shortcut in self.shortcuts.values() {
-            if shortcut.insert_type == InsertType::Surround && !shortcut.command.contains("#COMMAND") {
+            if shortcut.insert_type == InsertType::Surround
+                && !shortcut.command.contains("#COMMAND")
+            {
                 return Err(LeadrError::InvalidSurroundCommand(format!(
                     "Shortcut '{}' must contain '#COMMAND' in its command",
                     shortcut.command

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,8 +123,12 @@ impl Config {
         table.push_str(&table::render_header(&layout));
         table.push_str(&table::render_separator(&layout));
 
-        for (sequence, shortcut) in &self.shortcuts {
-            table.push_str(&table::render_row(&layout, sequence, shortcut));
+        let mut keys: Vec<_> = self.shortcuts.keys().collect();
+        keys.sort(); // Sorts alphabetically (lexicographically)
+
+        for key in keys {
+            let shortcut = &self.shortcuts[key];
+            table.push_str(&table::render_row(&layout, key, shortcut));
         }
 
         table

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,9 +3,10 @@ use std::collections::HashMap;
 use crossterm::event::{Event, KeyCode, KeyEvent, read};
 
 use crate::{
-    Config, LeadrError, ui::SequencePlotter,
+    Config, LeadrError,
     input::RawModeGuard,
     types::{Shortcut, ShortcutResult},
+    ui::SequencePlotter,
 };
 
 /// Handles keyboard input and matches sequences to configured shortcuts.
@@ -48,9 +49,7 @@ impl ShortcutHandler {
                         self.sequence.push(c);
                         let _ = self.ui.update(&self.sequence);
                         if let Some(shortcut) = self.match_sequence(&self.sequence) {
-                            return Ok(ShortcutResult::Shortcut(
-                                shortcut.format_command(),
-                            ));
+                            return Ok(ShortcutResult::Shortcut(shortcut.format_command()));
                         }
 
                         if !self.has_partial_match(&self.sequence) {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,4 +1,4 @@
-use crate::{keymap::to_ascii, Config, LeadrError};
+use crate::{Config, LeadrError, keymap::to_ascii};
 
 const BASH_INIT_TEMPLATE: &str = include_str!("../shell/init.bash");
 const ZSH_INIT_TEMPLATE: &str = include_str!("../shell/init.zsh");

--- a/src/types.rs
+++ b/src/types.rs
@@ -157,4 +157,3 @@ mod tests {
         assert_eq!(sc.format_command(), "SURROUND+EXEC dummy command");
     }
 }
-

--- a/src/ui/table.rs
+++ b/src/ui/table.rs
@@ -47,7 +47,10 @@ pub fn render_separator(layout: &ColumnLayout) -> String {
 
 fn truncate_string(cmd: &str, max_len: usize) -> String {
     if cmd.chars().count() > max_len {
-        cmd.chars().take(max_len.saturating_sub(3)).collect::<String>() + "..."
+        cmd.chars()
+            .take(max_len.saturating_sub(3))
+            .collect::<String>()
+            + "..."
     } else {
         cmd.to_string()
     }
@@ -61,7 +64,10 @@ pub fn render_row(layout: &ColumnLayout, sequence: &str, shortcut: &Shortcut) ->
         format!("{:?}", shortcut.insert_type),
         if shortcut.evaluate { "Yes" } else { "No" },
         if shortcut.execute { "Yes" } else { "No" },
-        truncate_string(&shortcut.description.clone().unwrap_or_default(), layout.description),
+        truncate_string(
+            &shortcut.description.clone().unwrap_or_default(),
+            layout.description
+        ),
         seq = layout.sequence,
         cmd = layout.command,
         typ = layout.insert_type,
@@ -70,4 +76,3 @@ pub fn render_row(layout: &ColumnLayout, sequence: &str, shortcut: &Shortcut) ->
         desc = layout.description,
     )
 }
-


### PR DESCRIPTION
This fixes #12 and sort the output of `--list` by the key sequence.