### PR TITLE
Fix prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,8 +266,10 @@ dependencies = [
  "crossterm",
  "directories",
  "serde",
+ "strip-ansi-escapes",
  "thiserror",
  "toml",
+ "unicode-width",
 ]
 
 [[package]]
@@ -490,6 +492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,10 +591,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "leadr"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leadr"
 description = "Shell aliases on steroids"
-version = "2.2.3"
+version = "2.3.0"
 edition = "2024"
 license = "MIT"
 authors = ["ll-nick"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ directories = "6.0.0"
 serde = {version = "1.0.219", features = ["derive"]}
 toml = "0.8.23"
 thiserror = "2.0.12"
+strip-ansi-escapes = "0.2.1"
+unicode-width = "0.2.1"

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -116,6 +116,10 @@ __leadr_invoke__() {
         local output_flags="${cmd%% *}"
         local to_insert="${cmd#* }"
 
+        if [[ -z "$cmd" ]]; then
+            return
+        fi
+
         local insert_type eval_flag exec_flag
         IFS='|' read -r insert_type eval_flag exec_flag <<< "$(leadr_parse_flags "$output_flags")"
 

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -113,7 +113,16 @@ __leadr_invoke__() {
     }
 
     leadr_main() {
-        local cmd="$(LEADR_CURSOR_LINE=$(leadr_cursor_line) leadr)"
+        local last_prompt_line=$(printf "%s" "${PS1@P}" | tail -n1)
+        local current_input="${READLINE_LINE}"
+
+        local cmd="$(
+            LEADR_CURSOR_LINE=$(leadr_cursor_line) \
+            LEADR_PROMPT="$last_prompt_line" \
+            LEADR_CURRENT_INPUT="$current_input" \
+                leadr
+        )"
+
         local output_flags="${cmd%% *}"
         local to_insert="${cmd#* }"
 

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -118,6 +118,7 @@ __leadr_invoke__() {
 
         local cmd="$(
             LEADR_CURSOR_LINE=$(leadr_cursor_line) \
+            LEADR_CURSOR_COLUMN=$READLINE_POINT \
             LEADR_PROMPT="$last_prompt_line" \
             LEADR_CURRENT_INPUT="$current_input" \
                 leadr

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -6,7 +6,8 @@ __leadr_invoke__() {
 
     leadr_cursor_line() {
         IFS='[;' read -sdR -p $'\E[6n' _ row col
-        echo "$row"
+        # row is 1-indexed, convert to 0-indexed
+        echo $((row - 1))
     }
 
     leadr_parse_flags() {

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -4,6 +4,15 @@ __leadr_invoke__() {
     LEADR_COMMAND_POSITION_ENCODING="#COMMAND"
     LEADR_CURSOR_POSITION_ENCODING="#CURSOR"
 
+    # Reference: https://stackoverflow.com/a/43911767
+    leadr_cursor_line() {
+      echo -ne "\033[6n" > /dev/tty
+      read -t 1 -s -d 'R' line < /dev/tty
+      line="${line##*\[}"
+      line="${line%;*}"
+      echo $((line - 1))
+    }
+
     leadr_parse_flags() {
         local flag_str="$1"
 
@@ -107,7 +116,7 @@ __leadr_invoke__() {
     }
 
     leadr_main() {
-        local cmd="$(leadr)"
+        local cmd="$(LEADR_CURSOR_LINE=$(leadr_cursor_line) leadr)"
         local output_flags="${cmd%% *}"
         local to_insert="${cmd#* }"
 

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -117,6 +117,9 @@ __leadr_invoke__() {
 
     leadr_main() {
         local cmd="$(LEADR_CURSOR_LINE=$(leadr_cursor_line) leadr)"
+
+        [[ -z "$cmd" ]] && return
+
         local output_flags="${cmd%% *}"
         local to_insert="${cmd#* }"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ pub struct Config {
     /// The key binding to activate leadr.
     pub leadr_key: String,
 
+    pub redraw_prompt_line: bool,
+
     /// Configuration for the keybinding panel.
     pub panel: PanelConfig,
 }
@@ -16,6 +18,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             leadr_key: "<C-g>".into(),
+            redraw_prompt_line: true,
             panel: PanelConfig::default(),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ pub struct Config {
     /// The key binding to activate leadr.
     pub leadr_key: String,
 
+    /// Bash only: Whether to redraw the prompt to cosmetically fix the prompt line
+    /// disappearing while leadr is active.
     pub redraw_prompt_line: bool,
 
     /// Configuration for the keybinding panel.

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,20 +3,38 @@ use std::time::{Duration, Instant};
 
 use crossterm::QueueableCommand;
 use crossterm::event::{Event, KeyCode, KeyEvent, poll, read};
+use unicode_width::UnicodeWidthStr;
 
 use crate::{Config, LeadrError, Mappings, Panel, Theme, input::RawModeGuard};
+
+fn visible_width(s: &str) -> usize {
+    // Remove ANSI escapes
+    let stripped_ansi = strip_ansi_escapes::strip(s);
+
+    // Convert back to string
+    let clean = String::from_utf8_lossy(&stripped_ansi);
+
+    // Compute terminal width
+    UnicodeWidthStr::width(clean.as_ref())
+}
 
 fn redraw_line() -> Result<(), LeadrError> {
     let mut tty = std::fs::OpenOptions::new().write(true).open("/dev/tty")?;
     let cursor_line = std::env::var("LEADR_CURSOR_LINE")?.parse::<u16>()?;
+    let cursor_column = std::env::var("LEADR_CURSOR_COLUMN")?.parse::<u16>()?;
     let prompt = std::env::var("LEADR_PROMPT")?;
     let input = std::env::var("LEADR_CURRENT_INPUT")?;
+    let prompt_width = visible_width(&prompt) as u16;
 
     tty.queue(crossterm::cursor::MoveTo(0, cursor_line))?
         .queue(crossterm::terminal::Clear(
             crossterm::terminal::ClearType::CurrentLine,
         ))?
         .queue(crossterm::style::Print(format!("{}{}", prompt, input)))?
+        .queue(crossterm::cursor::MoveTo(
+            prompt_width + cursor_column,
+            cursor_line,
+        ))?
         .flush()?;
 
     Ok(())

--- a/src/session.rs
+++ b/src/session.rs
@@ -31,13 +31,16 @@ impl LeadrSession {
     /// Runs the input loop, capturing key events and returning when a mapping is matched,
     /// canceled, or an invalid sequence is entered.
     pub fn run(&mut self) -> Result<SessionResult, LeadrError> {
-        let _guard = RawModeGuard::new()?;
+        let _raw_mode_guard = RawModeGuard::new()?;
         let start_time = Instant::now();
         let mut panel: Option<Panel> = None;
 
+        // Cosmetically fix the prompt line disappearing while leadr is active.
         let mut prompt_guard = prompt::PromptGuard::try_new();
         if let Ok(ref mut guard) = prompt_guard {
-            guard.redraw()?;
+            if self.config.redraw_prompt_line {
+                guard.redraw()?;
+            }
         }
 
         loop {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,44 +1,8 @@
-use std::io::Write;
 use std::time::{Duration, Instant};
 
-use crossterm::QueueableCommand;
 use crossterm::event::{Event, KeyCode, KeyEvent, poll, read};
-use unicode_width::UnicodeWidthStr;
 
-use crate::{Config, LeadrError, Mappings, Panel, Theme, input::RawModeGuard};
-
-fn visible_width(s: &str) -> usize {
-    // Remove ANSI escapes
-    let stripped_ansi = strip_ansi_escapes::strip(s);
-
-    // Convert back to string
-    let clean = String::from_utf8_lossy(&stripped_ansi);
-
-    // Compute terminal width
-    UnicodeWidthStr::width(clean.as_ref())
-}
-
-fn redraw_line() -> Result<(), LeadrError> {
-    let mut tty = std::fs::OpenOptions::new().write(true).open("/dev/tty")?;
-    let cursor_line = std::env::var("LEADR_CURSOR_LINE")?.parse::<u16>()?;
-    let cursor_column = std::env::var("LEADR_CURSOR_COLUMN")?.parse::<u16>()?;
-    let prompt = std::env::var("LEADR_PROMPT")?;
-    let input = std::env::var("LEADR_CURRENT_INPUT")?;
-    let prompt_width = visible_width(&prompt) as u16;
-
-    tty.queue(crossterm::cursor::MoveTo(0, cursor_line))?
-        .queue(crossterm::terminal::Clear(
-            crossterm::terminal::ClearType::CurrentLine,
-        ))?
-        .queue(crossterm::style::Print(format!("{}{}", prompt, input)))?
-        .queue(crossterm::cursor::MoveTo(
-            prompt_width + cursor_column,
-            cursor_line,
-        ))?
-        .flush()?;
-
-    Ok(())
-}
+use crate::{Config, LeadrError, Mappings, Panel, Theme, input::RawModeGuard, ui::prompt};
 
 pub enum SessionResult {
     Command(String),
@@ -71,7 +35,10 @@ impl LeadrSession {
         let start_time = Instant::now();
         let mut panel: Option<Panel> = None;
 
-        let _ = redraw_line();
+        let mut prompt_guard = prompt::PromptGuard::try_new();
+        if let Ok(ref mut guard) = prompt_guard {
+            guard.redraw()?;
+        }
 
         loop {
             let timeout_reached = start_time.elapsed() >= self.config.panel.timeout;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,5 @@
 pub mod panel;
+pub mod prompt;
 pub mod symbols;
 pub mod table;
 pub mod theme;

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -62,9 +62,9 @@ impl Panel {
         let mut tty = std::fs::OpenOptions::new().write(true).open("/dev/tty")?;
 
         let (_cols, rows) = terminal::size()?;
-        let cursor_line = std::env::var("LEADR_CURSOR_LINE")?.parse::<u16>()?;
+        let line_below_cursor = std::env::var("LEADR_CURSOR_LINE")?.parse::<u16>()? + 1;
 
-        let lines_below = rows.saturating_sub(cursor_line);
+        let lines_below = rows.saturating_sub(line_below_cursor);
         let scroll_up = config.height.saturating_sub(lines_below);
 
         if scroll_up > 0 {

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -90,7 +90,11 @@ impl PromptGuard {
 
 impl Drop for PromptGuard {
     fn drop(&mut self) {
-        // On exit, force cursor back to col 0 on its line
+        // On exit, prevent artifacts of the line redraw by clearing the line
+        // and moving the cursor back to the start of the input line.
         let _ = self.tty.execute(cursor::MoveTo(0, self.cursor_line));
+        let _ = self.tty.execute(crossterm::terminal::Clear(
+            crossterm::terminal::ClearType::CurrentLine,
+        ));
     }
 }

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Why do we need to redraw the line at all?
 //!
-//! When you invoke a `bind -x` command in Bash (or similar in Zsh), the shell
+//! When you invoke a `bind -x` command in Bash, the shell
 //! suspends its line editor (GNU Readline, ZLE, etc.) and executes your hook
 //! function/program. While your Rust program is running, the terminal is no
 //! longer "owned" by the shell's line editor.

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -1,0 +1,96 @@
+//! Line redraw module for Leadr.
+//!
+//! ## Why do we need to redraw the line at all?
+//!
+//! When you invoke a `bind -x` command in Bash (or similar in Zsh), the shell
+//! suspends its line editor (GNU Readline, ZLE, etc.) and executes your hook
+//! function/program. While your Rust program is running, the terminal is no
+//! longer "owned" by the shell's line editor.
+//! This means that the current line will be cleared and prompt and any previously
+//! typed input will not be visible during the execution of leadr.
+//!
+//! To give the illusion that the shell never "let go" of the line, leadr must
+//! explicitly repaint the prompt and input while it is active.
+//!
+//! This is wrapped into a RAII guard to ensure the cursor position is restored
+//! cleanly when leadr exits, not matter how it exits.
+
+use std::env;
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use crossterm::{ExecutableCommand, QueueableCommand, cursor};
+use unicode_width::UnicodeWidthStr;
+
+use crate::LeadrError;
+
+/// Compute the visible width of a string by stripping ANSI escape sequences
+/// and measuring Unicode display width.
+fn visible_width(s: &str) -> usize {
+    // Strip ANSI escapes
+    let stripped_ansi = strip_ansi_escapes::strip(s);
+
+    // Convert back to UTF-8 safely
+    let clean = String::from_utf8_lossy(&stripped_ansi);
+
+    // Measure grapheme width in terminal cells
+    UnicodeWidthStr::width(clean.as_ref())
+}
+
+/// Responsible for redrawing the shell line during the session.
+/// RAII guard ensures cursor is reset on drop.
+pub struct PromptGuard {
+    tty: std::fs::File,
+    cursor_line: u16,
+    cursor_column: u16,
+    prompt: String,
+    input: String,
+}
+
+impl PromptGuard {
+    /// Create a new redraw guard.
+    pub fn try_new() -> Result<Self, LeadrError> {
+        let tty = OpenOptions::new().write(true).open("/dev/tty")?;
+        let cursor_line = env::var("LEADR_CURSOR_LINE")?.parse::<u16>()?;
+        let cursor_column = env::var("LEADR_CURSOR_COLUMN")?.parse::<u16>()?;
+        let prompt = env::var("LEADR_PROMPT")?;
+        let input = env::var("LEADR_CURRENT_INPUT")?;
+
+        Ok(Self {
+            tty,
+            cursor_line,
+            cursor_column,
+            prompt,
+            input,
+        })
+    }
+
+    /// Redraw the current prompt + input line, restoring cursor position.
+    pub fn redraw(&mut self) -> Result<(), LeadrError> {
+        let prompt_width = visible_width(&self.prompt) as u16;
+
+        self.tty
+            .queue(crossterm::cursor::MoveTo(0, self.cursor_line))?
+            .queue(crossterm::terminal::Clear(
+                crossterm::terminal::ClearType::CurrentLine,
+            ))?
+            .queue(crossterm::style::Print(format!(
+                "{}{}",
+                self.prompt, self.input
+            )))?
+            .queue(crossterm::cursor::MoveTo(
+                prompt_width + self.cursor_column,
+                self.cursor_line,
+            ))?
+            .flush()?;
+
+        Ok(())
+    }
+}
+
+impl Drop for PromptGuard {
+    fn drop(&mut self) {
+        // On exit, force cursor back to col 0 on its line
+        let _ = self.tty.execute(cursor::MoveTo(0, self.cursor_line));
+    }
+}


### PR DESCRIPTION
This fixes two issues:

1. When exiting `leadr` without actually typing a full sequence, do not delete a command that was previously typed.
2. While `leadr` is active, the currently edited line of the shell disappeared. That removed important context especially for insert type commands. This PR fixes that by redrawing a previously existing prompt + command from rust giving the illusion that the edited line never changes until we actually fire a command via `leadr`.

This also fixes an issue where the zsh hook went out of sync with the bash version causing the panel to break.