### PR TITLE
Improve keybindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "leadr"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leadr"
 description = "Shell aliases on steroids"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2024"
 license = "MIT"
 authors = ["ll-nick"]

--- a/README.md
+++ b/README.md
@@ -107,8 +107,26 @@ To overwrite the default configuration directory (see [the directories crate](ht
 
 ### config.toml
 
-The main configuration file to set your `leadr` keybinding, tweak the keybinding panel and other global settings.
-For a list of currently supported keybindings, see [src/keymap.rs](src/keymap.rs).
+The main configuration file to set your `leadr` key, tweak the keybinding panel and other global settings.
+Most of these settings should be self-explanatory but here are some notes on a few of them:
+
+##### leadr_key
+
+The default keybinding is `<C-g>` (the `Ctrl` key and the `g` key pressed in one chord), but you can change that by modifying the `leadr_key` in the `config.toml` file.
+The syntax mimics that of Vim's keybindings, e.g. `<M-x>`, `<C-s>`, `<F5>`, etc. and supports chains like `<C-x><C-s>abc`.
+
+> **Fair warning**: Keybindings in the shell are a bit of an arcane mess.
+> I asked my good friend Chad Gibbidy to help me out with this.
+> Lots of bindings work but some don't.
+> Feel free to experiment but if you run into issues, `Ctrl` + a letter is probably your safest bet.
+
+##### redraw_prompt_line
+
+> **Note**: This setting concerns only `bash` users. It has no effect in `zsh`.
+
+Due to the way key bindings work in `bash`, the current prompt line will disappear while `leadr` is activated.
+To cover this up, `leadr` will redraw it after start-up.
+If you experience issues with this, you can disable it by setting `redraw_prompt_line = false`.
 
 ### Mappings
 

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -1,59 +1,242 @@
-use std::collections::HashMap;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::LeadrError;
+use crate::error::LeadrError;
 
-/// Converts a key name like `<C-a>` to its ASCII representation (`\x01`).
-///
-/// Returns an error if the key is unrecognized.
-pub fn to_ascii(key: &str) -> Result<String, LeadrError> {
-    let mut map = HashMap::new();
-    map.insert("<C-Space>", "\\x00");
-    map.insert("<C-a>", "\\x01");
-    map.insert("<C-b>", "\\x02");
-    map.insert("<C-d>", "\\x04");
-    map.insert("<C-e>", "\\x05");
-    map.insert("<C-f>", "\\x06");
-    map.insert("<C-g>", "\\x07");
-    map.insert("<C-h>", "\\x08");
-    map.insert("<C-i>", "\\x09");
-    map.insert("<C-j>", "\\x0A");
-    map.insert("<C-k>", "\\x0B");
-    map.insert("<C-l>", "\\x0C");
-    map.insert("<C-m>", "\\x0D");
-    map.insert("<C-n>", "\\x0E");
-    map.insert("<C-o>", "\\x0F");
-    map.insert("<C-p>", "\\x10");
-    map.insert("<C-q>", "\\x11");
-    map.insert("<C-r>", "\\x12");
-    map.insert("<C-s>", "\\x13");
-    map.insert("<C-t>", "\\x14");
-    map.insert("<C-u>", "\\x15");
-    map.insert("<C-v>", "\\x16");
-    map.insert("<C-w>", "\\x17");
-    map.insert("<C-x>", "\\x18");
-    map.insert("<C-y>", "\\x19");
-    map.insert("<C-z>", "\\x1A");
+/// Parses a single Vim-style key like `<C-x>`, `<M-Enter>`, `<F5>`.
+fn parse_vim_key(key: &str) -> Result<KeyEvent, LeadrError> {
+    let key = key.trim_matches(|c| c == '<' || c == '>');
+    let parts: Vec<&str> = key.split('-').collect();
 
-    match map.get(key) {
-        Some(&binding) => Ok(binding.to_string()),
-        None => Err(LeadrError::InvalidKeymapError(key.to_string())),
+    let mut ctrl = false;
+    let mut alt = false;
+    let mut shift = false;
+    let base_key;
+
+    if parts.len() > 1 {
+        // Treat first N-1 as modifiers, last as base key
+        for part in &parts[..parts.len() - 1] {
+            match part.to_uppercase().as_str() {
+                "C" => ctrl = true,
+                "M" => alt = true,
+                "S" => shift = true,
+                other => {
+                    return Err(LeadrError::InvalidKeymapError(format!(
+                        "Unknown modifier '{}'",
+                        other
+                    )));
+                }
+            }
+        }
+        base_key = parts[parts.len() - 1].to_string();
+    } else {
+        // Single element: literal
+        base_key = parts[0].to_string();
     }
+
+    let code = match base_key {
+        k if k.len() == 1 => KeyCode::Char(k.chars().next().unwrap()),
+        k => match k.to_uppercase().as_str() {
+            "SPACE" => KeyCode::Char(' '),
+            "CR" | "ENTER" => KeyCode::Enter,
+            "TAB" => KeyCode::Tab,
+            "ESC" => KeyCode::Esc,
+            "UP" => KeyCode::Up,
+            "DOWN" => KeyCode::Down,
+            "LEFT" => KeyCode::Left,
+            "RIGHT" => KeyCode::Right,
+            k if k.starts_with('F') => {
+                let n = k[1..].parse::<u8>().map_err(|_| {
+                    LeadrError::InvalidKeymapError(format!("Invalid function key: {}", key))
+                })?;
+                KeyCode::F(n)
+            }
+            _ => {
+                return Err(LeadrError::InvalidKeymapError(format!(
+                    "Unknown key: {}",
+                    key
+                )));
+            }
+        },
+    };
+
+    let mut modifiers = KeyModifiers::empty();
+    if ctrl {
+        modifiers |= KeyModifiers::CONTROL;
+    }
+    if alt {
+        modifiers |= KeyModifiers::ALT;
+    }
+    if shift {
+        modifiers |= KeyModifiers::SHIFT;
+    }
+
+    Ok(KeyEvent {
+        code,
+        modifiers,
+        kind: crossterm::event::KeyEventKind::Press,
+        state: crossterm::event::KeyEventState::NONE,
+    })
+}
+
+/// Converts a KeyEvent to a Bash/Zsh-compatible sequence
+fn keyevent_to_shell_seq(event: KeyEvent) -> String {
+    use KeyCode::*;
+    let mut s = String::new();
+
+    if event.modifiers.contains(KeyModifiers::ALT) {
+        s.push('\x1B'); // ESC prefix for Alt
+    }
+
+    match event.code {
+        Char(c) => {
+            let c = if event.modifiers.contains(KeyModifiers::CONTROL) {
+                (c as u8 & 0x1F) as char
+            } else if event.modifiers.contains(KeyModifiers::SHIFT) {
+                c.to_ascii_uppercase()
+            } else {
+                c
+            };
+            s.push(c);
+        }
+        Enter => s.push('\x0D'),
+        Tab => s.push('\x09'),
+        Esc => s.push('\x1B'),
+        Up => s.push_str("\x1B[A"),
+        Down => s.push_str("\x1B[B"),
+        Left => s.push_str("\x1B[D"),
+        Right => s.push_str("\x1B[C"),
+        F(n) => s.push_str(match n {
+            1 => "\x1BOP",
+            2 => "\x1BOQ",
+            3 => "\x1BOR",
+            4 => "\x1BOS",
+            5 => "\x1B[15~",
+            6 => "\x1B[17~",
+            7 => "\x1B[18~",
+            8 => "\x1B[19~",
+            9 => "\x1B[20~",
+            10 => "\x1B[21~",
+            11 => "\x1B[23~",
+            12 => "\x1B[24~",
+            _ => "",
+        }),
+        _ => {}
+    }
+
+    s
+}
+
+/// Parses a full Vim-style sequence like `<C-x><M-Enter>` into a shell string
+pub fn parse_keybinding(seq: &str) -> Result<String, LeadrError> {
+    let mut result = String::new();
+    let mut temp = String::new();
+    let mut in_angle = false;
+
+    for c in seq.chars() {
+        if c == '<' {
+            in_angle = true;
+            temp.push(c);
+        } else if c == '>' && in_angle {
+            temp.push(c);
+            in_angle = false;
+            let key_event = parse_vim_key(&temp)?;
+            result.push_str(&keyevent_to_shell_seq(key_event));
+            temp.clear();
+        } else if in_angle {
+            temp.push(c);
+        } else {
+            // plain character
+            result.push(c);
+        }
+    }
+
+    Ok(result)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::LeadrError;
+    use crossterm::event::{KeyCode, KeyModifiers};
 
     #[test]
-    fn test_valid_key_conversion() {
-        assert_eq!(to_ascii("<C-a>").unwrap(), "\\x01");
-        assert_eq!(to_ascii("<C-Space>").unwrap(), "\\x00");
+    fn test_parse_simple_char() {
+        let ev = parse_vim_key("x").unwrap();
+        assert_eq!(ev.code, KeyCode::Char('x'));
+        assert!(ev.modifiers.is_empty());
     }
 
     #[test]
-    fn test_invalid_key_conversion() {
-        let err = to_ascii("<C-unknown>");
-        assert!(matches!(err, Err(LeadrError::InvalidKeymapError(_))));
+    fn test_parse_ctrl_char() {
+        let ev = parse_vim_key("<C-a>").unwrap();
+        assert_eq!(ev.code, KeyCode::Char('a'));
+        assert!(ev.modifiers.contains(KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn test_parse_alt_shift_char() {
+        let ev = parse_vim_key("<M-S-x>").unwrap();
+        assert_eq!(ev.code, KeyCode::Char("x".chars().next().unwrap()));
+        assert!(ev.modifiers.contains(KeyModifiers::ALT));
+        assert!(ev.modifiers.contains(KeyModifiers::SHIFT));
+    }
+
+    #[test]
+    fn test_parse_named_keys() {
+        assert_eq!(parse_vim_key("<Enter>").unwrap().code, KeyCode::Enter);
+        assert_eq!(parse_vim_key("<Tab>").unwrap().code, KeyCode::Tab);
+        assert_eq!(parse_vim_key("<Esc>").unwrap().code, KeyCode::Esc);
+        assert_eq!(parse_vim_key("<Up>").unwrap().code, KeyCode::Up);
+        assert_eq!(parse_vim_key("<Down>").unwrap().code, KeyCode::Down);
+        assert_eq!(parse_vim_key("<Left>").unwrap().code, KeyCode::Left);
+        assert_eq!(parse_vim_key("<Right>").unwrap().code, KeyCode::Right);
+    }
+
+    #[test]
+    fn test_parse_function_keys() {
+        assert_eq!(parse_vim_key("<F1>").unwrap().code, KeyCode::F(1));
+        assert_eq!(parse_vim_key("<F12>").unwrap().code, KeyCode::F(12));
+        assert!(parse_vim_key("<F13>").is_ok()); // still parsed, but no mapping in keyevent_to_shell_seq
+    }
+
+    #[test]
+    fn test_keyevent_to_shell_seq_ctrl() {
+        let ev = parse_vim_key("<C-g>").unwrap();
+        let seq = keyevent_to_shell_seq(ev);
+        assert_eq!(seq, "\x07"); // Ctrl-G
+    }
+
+    #[test]
+    fn test_keyevent_to_shell_seq_alt() {
+        let ev = parse_vim_key("<M-x>").unwrap();
+        let seq = keyevent_to_shell_seq(ev);
+        assert_eq!(seq, "\x1Bx"); // ESC + 'x'
+    }
+
+    #[test]
+    fn test_parse_sequence_mixed() {
+        let seq = parse_keybinding("<C-x><M-Enter>abc").unwrap();
+        assert_eq!(seq, "\x18\x1B\rabc");
+    }
+
+    #[test]
+    fn test_invalid_modifier() {
+        let err = parse_vim_key("<Q-x>").unwrap_err();
+        match err {
+            LeadrError::InvalidKeymapError(s) => {
+                assert!(s.contains("Unknown modifier"));
+            }
+            _ => panic!("Unexpected error type"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_key() {
+        let err = parse_vim_key("<C-NotAKey>").unwrap_err();
+        match err {
+            LeadrError::InvalidKeymapError(s) => {
+                assert!(s.contains("Unknown key"));
+            }
+            _ => panic!("Unexpected error type"),
+        }
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,18 +1,18 @@
-use crate::{Config, LeadrError, keymap::to_ascii};
+use crate::{Config, LeadrError, keymap::parse_keybinding};
 
 const BASH_INIT_TEMPLATE: &str = include_str!("../shell/init.bash");
 const ZSH_INIT_TEMPLATE: &str = include_str!("../shell/init.zsh");
 
 /// Generates a bash script that handles the resulting command and binds it to the leadr key.
 pub fn init_bash(config: &Config) -> Result<String, LeadrError> {
-    let leader_key = to_ascii(&config.leadr_key)?;
+    let leader_key = parse_keybinding(&config.leadr_key)?;
 
     Ok(BASH_INIT_TEMPLATE.replace("{{bind_key}}", &leader_key))
 }
 
 /// Generates a zsh script that handles the resulting command and binds it to the leadr key.
 pub fn init_zsh(config: &Config) -> Result<String, LeadrError> {
-    let leader_key = to_ascii(&config.leadr_key)?;
+    let leader_key = parse_keybinding(&config.leadr_key)?;
 
     Ok(ZSH_INIT_TEMPLATE.replace("{{bind_key}}", &leader_key))
 }
@@ -26,13 +26,13 @@ mod tests {
     fn test_bash_script_contains_replacements() {
         let config = Config::default();
         let result = init_bash(&config).unwrap();
-        assert!(result.contains("\\x07"));
+        assert!(result.contains("\x07"));
     }
 
     #[test]
     fn test_zsh_script_contains_replacements() {
         let config = Config::default();
         let result = init_zsh(&config).unwrap();
-        assert!(result.contains("\\x07"));
+        assert!(result.contains("\x07"));
     }
 }


### PR DESCRIPTION
This replaces the simple map "translating" vim-style keybindings into a format that the shell understands by an actual parser. This allows additional keybindings and even chains of key presses without having to list them all explicitly.

Some of the successfully tested combinations are e.g. `<C-a>`, `<M-a>`, `<C-]>`, `<C-x><C-o>`, `<C-x><C-o>abc`, `<F11>`.

Not all combinations work but this is due to the way key bindings are handled by the shell.