### PR TITLE
Add shell test

### DIFF
--- a/shell/test/mappings.toml
+++ b/shell/test/mappings.toml
@@ -1,0 +1,68 @@
+[r1]
+command = "This should replace the entire line"
+description = "Test Replace"
+insert_type = "Replace"
+
+[r2]
+command = "This should replace the entire line. CURSOR->#CURSOR<-HERE"
+description = "Test Replace with Cursor"
+insert_type = "Replace"
+
+[i1]
+command = "This should be inserted at the cursor position"
+description = "Test Insert"
+insert_type = "Insert"
+
+[i2]
+command = "This should be inserted at the cursor position. CURSOR->#CURSOR<-HERE"
+description = "Test Insert with Cursor"
+insert_type = "Insert"
+
+[p1]
+command = "This should be prepended to the line"
+description = "Test Prepend"
+insert_type = "Prepend"
+
+[p2]
+command = "This should be prepended to the line. CURSOR->#CURSOR<-HERE"
+description = "Test Prepend with Cursor"
+insert_type = "Prepend"
+
+[a1]
+command = "This should be appended to the line"
+description = "Test Append"
+insert_type = "Append"
+
+[a2]
+command = "This should be appended to the line. CURSOR->#CURSOR<-HERE"
+description = "Test Append with Cursor"
+insert_type = "Append"
+
+[s1]
+command = "Before [ #COMMAND ] After"
+description = "Test Surround"
+insert_type = "Surround"
+
+[s2]
+command = "Before [ #COMMAND ->#CURSOR<-] After"
+description = "Test Surround with Cursor"
+insert_type = "Surround"
+
+[e1]
+command = "echo 'Command executed'"
+description = "Test Execute"
+insert_type = "Replace"
+execute = true
+
+[e2]
+command = "date"
+description = "Test Evaluate"
+insert_type = "Insert"
+evaluate = true
+
+[e3]
+command = "which date"
+description = "Test Evaluate + Execute"
+insert_type = "Replace"
+evaluate = true
+execute = true

--- a/shell/test/source_me.sh
+++ b/shell/test/source_me.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+export LEADR_CONFIG_DIR="$SCRIPT_DIR"
+
+BIND_KEY="\C-g"
+
+CURRENT_SHELL=$(basename "$SHELL")
+case "$CURRENT_SHELL" in
+    bash)
+        INIT_FILE="$SCRIPT_DIR/../init.bash"
+        ;;
+    zsh)
+        INIT_FILE="$SCRIPT_DIR/../init.zsh"
+        ;;
+    *)
+        echo "Unsupported shell: $CURRENT_SHELL"
+        return 1 2>/dev/null || exit 1
+        ;;
+esac
+
+source <(sed "s/{{bind_key}}/$BIND_KEY/" "$INIT_FILE")


### PR DESCRIPTION
In preparation of adding fish support, this adds a small but reproducible test setup. An automated setup would be even cooler but I'm not sure how that would work. So instead, this defines a set of mappings that should cover all the insert types as well as the evaluate and execute features. Using these mappings, we can then manually make sure that the individual shell integrations work as expected.