### PR TITLE
Fix cursor positioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "leadr"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leadr"
 description = "Shell aliases on steroids"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 license = "MIT"
 authors = ["ll-nick"]

--- a/shell/init.bash
+++ b/shell/init.bash
@@ -85,7 +85,7 @@ __leadr_invoke__() {
                         READLINE_POINT=$((cursor_pos - ${#LEADR_COMMAND_POSITION_ENCODING} + ${#original_line}))
                     fi
                 else
-                    READLINE_POINT=${#READLINE_LINE}
+                    READLINE_POINT=$((${#before_command} + original_point))
                 fi
                 ;;
             *)

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -89,7 +89,7 @@ __leadr_invoke__() {
                         CURSOR=$(($cursor_pos - ${#LEADR_COMMAND_POSITION_ENCODING} + ${#original_buffer}))
                     fi
                 else
-                    CURSOR=${#BUFFER}
+                    CURSOR=$((${#before} + original_cursor))
                 fi
                 ;;
             *)

--- a/shell/init.zsh
+++ b/shell/init.zsh
@@ -49,17 +49,18 @@ __leadr_invoke__() {
         local to_insert="$2"
         local cursor_pos="$3"
 
+        local original_cursor=$CURSOR
+
         case "$insert_type" in
             INSERT)
                 LBUFFER+="$to_insert"
                 if [[ $cursor_pos -ge 0 ]]; then
-                    CURSOR=$((CURSOR + cursor_pos))
+                    CURSOR=$((original_cursor + cursor_pos))
                 else
-                    CURSOR=$((CURSOR + ${#to_insert}))
+                    CURSOR=$((original_cursor + ${#to_insert}))
                 fi
                 ;;
             PREPEND)
-                local original_cursor=$CURSOR
                 BUFFER="${to_insert}${BUFFER}"
                 if [[ $cursor_pos -ge 0 ]]; then
                     CURSOR=$cursor_pos


### PR DESCRIPTION
This is a minor bug fix regarding the cursor positioning for insert mappings in zsh.
The previously merged shell test helpers allowed a more structured approach to test all the mapping types which uncovered this bug.

Additionally, the surround cursor positon has been adjusted in both bash and zsh to keep the cursor where it was before. I believe that is the expected behavior and also more in line with what the other insert types do when no explicit cursor position was defined.