### PR TITLE
Another fix for macOS I/O errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "filedescriptor",
  "mio",
  "parking_lot",
  "rustix",
@@ -278,6 +279,17 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -518,7 +530,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -658,11 +670,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leadr"
-version = "2.8.2"
+version = "2.8.3"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leadr"
 description = "Shell aliases on steroids"
-version = "2.8.2"
+version = "2.8.3"
 edition = "2024"
 license = "MIT"
 authors = ["ll-nick"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 clap = {version = "4.5.37", features = ["derive"] }
-crossterm = "0.29.0"
+crossterm = {version = "0.29.0", features = ["use-dev-tty"] }
 directories = "6.0.0"
 serde = {version = "1.0.219", features = ["derive"]}
 toml = "0.8.23"

--- a/README.md
+++ b/README.md
@@ -209,4 +209,4 @@ and set `theme_name = "high-contrast"` in the `config.toml` file.
 ## ❤️ Contributions
 
 Thanks @Banh-Canh for contributing the fish integration!  
-Thanks @johnallen3d for testing `leadr` on macOS!
+Thanks @johnallen3d and @bjohnso5 for testing `leadr` on macOS!


### PR DESCRIPTION
Closes #42 - for good this time.

This fixes an issue experiences by macOS users. The fact that `leadr` is invoked via a shell script (meaning stdin/stdout are redirected) requires a special feature flag in the `crossterm` crate on macOS systems, see e.g. [this issue](https://github.com/crossterm-rs/crossterm/issues/939) for reference.

Thanks @bjohnso5 for reporting this and testing out the solution.