### PR TITLE
docs: add Homebrew installation section and example formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ This will install the latest version of `leadr` from [crates.io](https://crates.
 </details>
 
 <details>
+<summary>From Homebrew 🍺 (community tap)</summary>
+On macOS or Linux with [Homebrew](https://brew.sh/) installed, you can use a community-maintained tap:
+
+```bash
+brew tap ltaupiac/leadr
+brew install leadr
+```
+
+- This tap builds `leadr` from the official GitHub release tarball using the Rust toolchain.
+
+</details>
+
+<details>
 <summary>From source</summary>
 
 You can build `leadr` from source using cargo:

--- a/packaging/homebrew/leadr.rb
+++ b/packaging/homebrew/leadr.rb
@@ -1,0 +1,17 @@
+class Leadr < Formula
+  desc "Leader-key inspired command runner"
+  homepage "https://github.com/ll-nick/leadr"
+  url "https://github.com/ll-nick/leadr/archive/refs/tags/v2.6.1.tar.gz"
+  sha256 "aaf23e5f521911ab766876e96dd75422499db7f4d1316539bbfc36cbadabfa71"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    system "#{bin}/leadr", "--help"
+  end
+end


### PR DESCRIPTION
This PR adds a Homebrew installation option and an example Homebrew formula for `leadr`.

## Changes

1. **README.md**
   - Added a new “From Homebrew 🍺 (community tap)” section under the “📦 Installation” heading.
   - Documented installation via a community-maintained tap:

     ```bash
     brew tap ltaupiac/leadr
     brew install leadr
     ```

   - This tap builds `leadr` from the official GitHub release tarball using the Rust toolchain.

2. **packaging/homebrew/leadr.rb**
   - Added an example Homebrew formula that:
     - Uses the official GitHub release tarball (`v2.6.1`):
       ```ruby
       url "https://github.com/ll-nick/leadr/archive/refs/tags/v2.6.1.tar.gz"
       ```
     - Builds `leadr` from source with:

       ```ruby
       depends_on "rust" => :build

       def install
         system "cargo", "install", *std_cargo_args
       end
       ```

## Notes

- The tap `ltaupiac/leadr` is community-maintained and currently hosts this formula.
- If you ever decide to host an official tap (e.g. `ll-nick/homebrew-leadr`), the formula in `packaging/homebrew/leadr.rb` can be used as-is or as a starting point.
- Once an official tap exists, the README Homebrew section can easily be updated to point to your tap instead of mine.