### PR TITLE
Enforce formatting and linting, improve code quality

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1,18 +1,22 @@
-name: Run tests
+name: Run checks
 on:
   push:
 env:
   CARGO_TERM_COLOR: always
 jobs:
-  build:
+  run_checks:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - name: Check formatting
       run: cargo fmt --all -- --check
+
     - name: Check linting
       run: cargo clippy --all-targets --all-features -- -D warnings
+
     - name: Build
       run: cargo build --locked --verbose
+
     - name: Run tests
       run: cargo test --locked --verbose

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Check formatting
+      run: cargo fmt --all -- --check
     - name: Build
       run: cargo build --locked --verbose
     - name: Run tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,6 +10,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Check formatting
       run: cargo fmt --all -- --check
+    - name: Check linting
+      run: cargo clippy --all-targets --all-features -- -D warnings
     - name: Build
       run: cargo build --locked --verbose
     - name: Run tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --locked --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --locked --verbose

--- a/src/keybinding/bash_zsh.rs
+++ b/src/keybinding/bash_zsh.rs
@@ -56,13 +56,13 @@ mod tests {
 
     #[test]
     fn test_keyevent_to_shell_seq_ctrl() {
-        let seq = keyevent_to_shell_seq(parse_keysequence("<C-g>").unwrap()[0].clone());
+        let seq = keyevent_to_shell_seq(parse_keysequence("<C-g>").unwrap()[0]);
         assert_eq!(seq, "\x07"); // Ctrl-G
     }
 
     #[test]
     fn test_keyevent_to_shell_seq_alt() {
-        let seq = keyevent_to_shell_seq(parse_keysequence("<M-x>").unwrap()[0].clone());
+        let seq = keyevent_to_shell_seq(parse_keysequence("<M-x>").unwrap()[0]);
         assert_eq!(seq, "\x1Bx"); // ESC + 'x'
     }
 }

--- a/src/keybinding/fish.rs
+++ b/src/keybinding/fish.rs
@@ -46,7 +46,7 @@ pub fn fish_keyevent_to_shell_seq(ev: KeyEvent) -> String {
         _ => "".into(),
     };
 
-    return format!("{}{}", modifier, keycode);
+    format!("{}{}", modifier, keycode)
 }
 
 #[cfg(test)]

--- a/src/keybinding/fish.rs
+++ b/src/keybinding/fish.rs
@@ -56,21 +56,19 @@ mod tests {
 
     #[test]
     fn test_fish_fields_simple() {
-        let seq = fish_keyevent_to_shell_seq(parse_keysequence("<C-g>").unwrap()[0].clone());
+        let seq = fish_keyevent_to_shell_seq(parse_keysequence("<C-g>").unwrap()[0]);
         assert_eq!(seq, "ctrl-g");
     }
 
     #[test]
     fn test_fish_fields_combo() {
-        let seq = fish_keyevent_to_shell_seq(parse_keysequence("<C-M-S-x>").unwrap()[0].clone());
+        let seq = fish_keyevent_to_shell_seq(parse_keysequence("<C-M-S-x>").unwrap()[0]);
         assert_eq!(seq, "ctrl-alt-shift-x");
     }
 
     #[test]
     fn test_fish_fields_non_char() {
-        let seq = fish_keyevent_to_shell_seq(parse_keysequence("<F5>").unwrap()[0].clone());
+        let seq = fish_keyevent_to_shell_seq(parse_keysequence("<F5>").unwrap()[0]);
         assert_eq!(seq, "f5");
     }
-
-
 }

--- a/src/keybinding/nushell.rs
+++ b/src/keybinding/nushell.rs
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn test_nushell_fields_simple() {
         let ev = parse_keysequence("<C-g>").unwrap();
-        let fields = nushell_keyevent_to_fields(ev.first().unwrap().clone()).unwrap();
+        let fields = nushell_keyevent_to_fields(*ev.first().unwrap()).unwrap();
         assert_eq!(fields.modifier, "Control");
         assert_eq!(fields.keycode, "Char_g");
     }
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn test_nushell_fields_combo() {
         let ev = parse_keysequence("<C-M-S-x>").unwrap();
-        let fields = nushell_keyevent_to_fields(ev.first().unwrap().clone()).unwrap();
+        let fields = nushell_keyevent_to_fields(*ev.first().unwrap()).unwrap();
         assert_eq!(fields.modifier, "Control_Alt_Shift");
         assert_eq!(fields.keycode, "Char_x");
     }
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn test_nushell_fields_non_char() {
         let ev = parse_keysequence("<F5>").unwrap();
-        let fields = nushell_keyevent_to_fields(ev.first().unwrap().clone()).unwrap();
+        let fields = nushell_keyevent_to_fields(*ev.first().unwrap()).unwrap();
         assert_eq!(fields.keycode, "F5");
         assert_eq!(fields.modifier, "None");
     }

--- a/src/keybinding/shell_binding.rs
+++ b/src/keybinding/shell_binding.rs
@@ -48,10 +48,9 @@ pub fn keyevents_to_shell_binding(
         Shell::Fish => {
             let key_code_string = events
                 .iter()
-                .map(|ev| fish_keyevent_to_shell_seq(*ev) + ",")
-                .collect::<String>();
-
-            let key_code_string = key_code_string.trim_end_matches(",");
+                .map(|ev| fish_keyevent_to_shell_seq(*ev))
+                .collect::<Vec<_>>()
+                .join(",");
 
             Ok(format!("\nbind {} {}\n", key_code_string, function_name))
         }

--- a/src/keybinding/shell_binding.rs
+++ b/src/keybinding/shell_binding.rs
@@ -32,7 +32,7 @@ pub fn keyevents_to_shell_binding(
                 .map(|ev| keyevent_to_shell_seq(*ev))
                 .collect::<String>();
 
-            return Ok(format!(
+            Ok(format!(
                 "\nbind -m emacs -x '\"{}\":{}'\n\
                  bind -m vi-insert -x '\"{}\":{}'\n\
                  # In vi-command mode, switch to insert mode, invoke leadr using the binding defined above, then return to command mode\n\
@@ -43,7 +43,7 @@ pub fn keyevents_to_shell_binding(
                 function_name,
                 key_code_string,
                 function_name,
-            ));
+            ))
         }
         Shell::Fish => {
             let key_code_string = events
@@ -53,7 +53,7 @@ pub fn keyevents_to_shell_binding(
 
             let key_code_string = key_code_string.trim_end_matches(",");
 
-            return Ok(format!("\nbind {} {}\n", key_code_string, function_name));
+            Ok(format!("\nbind {} {}\n", key_code_string, function_name))
         }
         Shell::Nushell => {
             ensure!(
@@ -86,11 +86,11 @@ pub fn keyevents_to_shell_binding(
                 .map(|ev| keyevent_to_shell_seq(*ev))
                 .collect::<String>();
 
-            return Ok(format!(
+            Ok(format!(
                 "zle -N {}\n\
                 bindkey '{}' {}",
                 function_name, key_code_string, function_name
-            ));
+            ))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,11 +99,9 @@ fn main() -> Result<()> {
 fn get_config_dir() -> Result<PathBuf> {
     if let Ok(custom_path) = std::env::var("LEADR_CONFIG_DIR") {
         Ok(PathBuf::from(custom_path))
+    } else if let Some(path) = ProjectDirs::from("com", "leadr", "leadr") {
+        Ok(path.config_dir().to_path_buf())
     } else {
-        if let Some(path) = ProjectDirs::from("com", "leadr", "leadr") {
-            Ok(path.config_dir().to_path_buf())
-        } else {
-            Err(eyre!("Could not determine configuration directory."))
-        }
+        Err(eyre!("Could not determine configuration directory."))
     }
 }

--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -227,11 +227,12 @@ impl Mappings {
     pub fn next_possible_keys(&self, sequence: &str) -> BTreeSet<String> {
         let mut next_keys = BTreeSet::new();
 
-        for (key, _) in &self.mappings {
-            if key.starts_with(sequence) {
-                if let Some((_, ch)) = key[sequence.len()..].char_indices().next() {
-                    next_keys.insert(ch.to_string());
-                }
+        for key in self.mappings.keys() {
+            if let Some(next_char) = key
+                .strip_prefix(sequence)
+                .and_then(|rest| rest.chars().next())
+            {
+                next_keys.insert(next_char.to_string());
             }
         }
 

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -171,7 +171,7 @@ impl Panel {
                 .take(column.height as usize)
                 .cloned()
                 .collect::<Vec<_>>();
-            self.draw_entries(&mut tty, column, &mappings, &sequence, &column_keys)?;
+            self.draw_entries(&mut tty, column, mappings, sequence, &column_keys)?;
         }
 
         let footer_area = Area {


### PR DESCRIPTION
This adds a formatting and a linting step to the workflow that's run at every push and renames it to `run_checks`. Coincidentally, this PR fixes some issues that clippy brought up improving the overall code quality.