### PR TITLE
Refresh dependencies and CI tooling, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      cargo-dependencies:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,114 @@
+name: Release dry-run
+
+# Validates the release pipeline (artifact upload/download + release-action) against the
+# pinned action versions WITHOUT publishing: creates a draft GitHub release and skips
+# crates.io and Homebrew.
+# Trigger by pushing a tag like `test-v2.8.6`
+
+on:
+  push:
+    tags:
+      - test-v*
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [
+          x86_64-unknown-linux-musl,
+          aarch64-unknown-linux-musl,
+          armv7-unknown-linux-musleabihf
+        ]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Build with cross
+        run: cross build --locked --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/leadr dist/leadr-${{ github.ref_name }}-${{ matrix.target }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: leadr-${{ github.ref_name }}-${{ matrix.target }}
+          path: dist/leadr-${{ github.ref_name }}-${{ matrix.target }}
+
+  build-macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build (macOS)
+        run: cargo build --locked --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/leadr dist/leadr-${{ github.ref_name }}-${{ matrix.target }}
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: leadr-${{ github.ref_name }}-${{ matrix.target }}
+          path: dist/leadr-${{ github.ref_name }}-${{ matrix.target }}
+
+  draft-release:
+    needs: [build-linux, build-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: actions/download-artifact@v8
+        with:
+          merge-multiple: true
+          path: dist
+
+      - name: Inspect downloaded assets
+        run: |
+          ls -lR dist
+          file dist/* || true
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          set -e
+
+          echo -e "TEST RELEASE | DELETE LATER\nThis release contains the following changes:\n\n---\n" > release_notes.md
+
+          PREV_TAG=$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || echo "")
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found, including all merge commits."
+            git log --merges --pretty=format:'### %s%n%n%b%n%n---' >> release_notes.md
+          else
+            echo "Previous tag: $PREV_TAG"
+            git log "$PREV_TAG"..HEAD --merges --pretty=format:'### %s%n%n%b%n%n---' >> release_notes.md
+          fi
+
+          echo "Generated release notes:"
+          cat release_notes.md
+
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          bodyFile: release_notes.md
+          draft: true
+          prerelease: true
+          name: "DRY RUN ${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install toml-cli
         run: cargo install toml-cli
       - name: Check version
@@ -31,7 +31,7 @@ jobs:
           armv7-unknown-linux-musleabihf
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install cross
         run: cargo install cross
@@ -44,7 +44,7 @@ jobs:
           mkdir -p dist
           cp target/${{ matrix.target }}/release/leadr dist/leadr-${{ github.ref_name }}-${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: leadr-${{ github.ref_name }}-${{ matrix.target }}
           path: dist/leadr-${{ github.ref_name }}-${{ matrix.target }}
@@ -57,7 +57,7 @@ jobs:
       matrix:
         target: [x86_64-apple-darwin, aarch64-apple-darwin]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust target
         run: rustup target add ${{ matrix.target }}
@@ -70,7 +70,7 @@ jobs:
           mkdir -p dist
           cp target/${{ matrix.target }}/release/leadr dist/leadr-${{ github.ref_name }}-${{ matrix.target }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: leadr-${{ github.ref_name }}-${{ matrix.target }}
           path: dist/leadr-${{ github.ref_name }}-${{ matrix.target }}
@@ -80,12 +80,12 @@ jobs:
     needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: dist
@@ -119,7 +119,7 @@ jobs:
     needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -7,7 +7,7 @@ jobs:
   run_checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Check formatting
       run: cargo fmt --all -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,15 +34,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "cfg-if"
@@ -96,9 +96,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "color-eyre"
@@ -163,15 +163,15 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -206,22 +206,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -294,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -311,9 +312,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -329,9 +330,9 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -365,25 +366,24 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litrs"
@@ -402,15 +402,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -462,9 +462,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -491,24 +491,24 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -530,20 +530,29 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -557,6 +566,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -629,18 +644,19 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -659,9 +675,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -679,11 +695,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -699,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -760,9 +776,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -770,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -790,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "sharded-slab",
  "thread_local",
@@ -801,15 +817,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -883,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leadr"
-version = "2.8.5"
+version = "2.8.6"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,11 +605,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -735,44 +735,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -899,9 +897,6 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = {version = "4.5.37", features = ["derive"] }
 crossterm = {version = "0.29.0", features = ["use-dev-tty"] }
 directories = "6.0.0"
 serde = {version = "1.0.219", features = ["derive"]}
-toml = "0.8.23"
+toml = "1"
 strip-ansi-escapes = "0.2.1"
 unicode-width = "0.2.1"
 color-eyre = "0.6.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leadr"
 description = "Shell aliases on steroids"
-version = "2.8.5"
+version = "2.8.6"
 edition = "2024"
 license = "MIT"
 authors = ["ll-nick"]

--- a/src/keybinding/fish.rs
+++ b/src/keybinding/fish.rs
@@ -42,11 +42,11 @@ pub fn fish_keyevent_to_shell_seq(ev: KeyEvent) -> String {
         Down => "down".into(),
         Left => "left".into(),
         Right => "right".into(),
-        F(n) => format!("f{}", n),
+        F(n) => format!("f{n}"),
         _ => "".into(),
     };
 
-    format!("{}{}", modifier, keycode)
+    format!("{modifier}{keycode}")
 }
 
 #[cfg(test)]

--- a/src/keybinding/nushell.rs
+++ b/src/keybinding/nushell.rs
@@ -35,7 +35,7 @@ pub fn nushell_keyevent_to_fields(ev: KeyEvent) -> Result<NushellKeyFields> {
         Esc => "Esc".into(),
         Tab => "Tab".into(),
         Char(' ') => "Space".into(),
-        Char(c) => format!("Char_{}", c),
+        Char(c) => format!("Char_{c}"),
         Delete => "Delete".into(),
         Insert => "Insert".into(),
         Home => "Home".into(),
@@ -46,7 +46,7 @@ pub fn nushell_keyevent_to_fields(ev: KeyEvent) -> Result<NushellKeyFields> {
         Down => "Down".into(),
         Left => "Left".into(),
         Right => "Right".into(),
-        F(n) => format!("F{}", n),
+        F(n) => format!("F{n}"),
         Null => "Null".into(),
         BackTab => "BackTab".into(),
         _ => {

--- a/src/keybinding/parse.rs
+++ b/src/keybinding/parse.rs
@@ -156,22 +156,20 @@ mod tests {
     #[test]
     fn test_invalid_modifier() {
         let err = parse_vim_key("<Q-x>").unwrap_err();
-        let msg = format!("{}", err); // get the error message
+        let msg = format!("{err}"); // get the error message
         assert!(
             msg.contains("not a recognized modifier"),
-            "Error message: {}",
-            msg
+            "Error message: {msg}"
         );
     }
 
     #[test]
     fn test_invalid_key() {
         let err = parse_vim_key("<C-NotAKey>").unwrap_err();
-        let msg = format!("{}", err); // get the error message
+        let msg = format!("{err}"); // get the error message
         assert!(
             msg.contains("not a recognized keycode"),
-            "Error message: {}",
-            msg
+            "Error message: {msg}"
         );
     }
 

--- a/src/keybinding/shell_binding.rs
+++ b/src/keybinding/shell_binding.rs
@@ -33,16 +33,10 @@ pub fn keyevents_to_shell_binding(
                 .collect::<String>();
 
             Ok(format!(
-                "\nbind -m emacs -x '\"{}\":{}'\n\
-                 bind -m vi-insert -x '\"{}\":{}'\n\
+                "\nbind -m emacs -x '\"{key_code_string}\":{function_name}'\n\
+                 bind -m vi-insert -x '\"{key_code_string}\":{function_name}'\n\
                  # In vi-command mode, switch to insert mode, invoke leadr using the binding defined above, then return to command mode\n\
-                 bind -m vi-command '\"{}\":i{}\\e'\n",
-                key_code_string,
-                function_name,
-                key_code_string,
-                function_name,
-                key_code_string,
-                function_name,
+                 bind -m vi-command '\"{key_code_string}\":i{function_name}\\e'\n",
             ))
         }
         Shell::Fish => {
@@ -52,7 +46,7 @@ pub fn keyevents_to_shell_binding(
                 .collect::<Vec<_>>()
                 .join(",");
 
-            Ok(format!("\nbind {} {}\n", key_code_string, function_name))
+            Ok(format!("\nbind {key_code_string} {function_name}\n"))
         }
         Shell::Nushell => {
             ensure!(
@@ -86,9 +80,8 @@ pub fn keyevents_to_shell_binding(
                 .collect::<String>();
 
             Ok(format!(
-                "zle -N {}\n\
-                bindkey '{}' {}",
-                function_name, key_code_string, function_name
+                "zle -N {function_name}\n\
+                bindkey '{key_code_string}' {function_name}"
             ))
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
         Config::create_default(&config_dir)?;
         Mappings::create_default(&config_dir)?;
 
-        println!("Default config and mappings created in {:?}", config_dir);
+        println!("Default config and mappings created in {config_dir:?}");
         return Ok(());
     }
 
@@ -57,25 +57,25 @@ fn main() -> Result<()> {
     if cli.bash {
         let script =
             leadr::init_bash(&config).wrap_err("Failed to generate Bash initialization script.")?;
-        print!("{}", script);
+        print!("{script}");
         return Ok(());
     }
     if cli.fish {
         let script =
             leadr::init_fish(&config).wrap_err("Failed to generate Fish initialization script.")?;
-        print!("{}", script);
+        print!("{script}");
         return Ok(());
     }
     if cli.nu {
         let script = leadr::init_nushell(&config)
             .wrap_err("Failed to generate NuShell initialization script.")?;
-        print!("{}", script);
+        print!("{script}");
         return Ok(());
     }
     if cli.zsh {
         let script =
             leadr::init_zsh(&config).wrap_err("Failed to generate Zsh initialization script.")?;
-        print!("{}", script);
+        print!("{script}");
         return Ok(());
     }
 
@@ -88,7 +88,7 @@ fn main() -> Result<()> {
 
     match session.run().wrap_err("Failed to execute leadr session.")? {
         SessionResult::Command(command) => {
-            print!("{}", command);
+            print!("{command}");
         }
         SessionResult::NoMatch | SessionResult::Cancelled => {}
     }

--- a/src/ui/entry.rs
+++ b/src/ui/entry.rs
@@ -26,11 +26,11 @@ impl Entry {
                 let flags = format_flags(mapping, symbols);
                 (label, flags, false)
             }
-            MatchType::Prefix(count) => (format!("+{} mappings", count), " ".repeat(5), true),
+            MatchType::Prefix(count) => (format!("+{count} mappings"), " ".repeat(5), true),
             MatchType::None => ("(invalid)".into(), "".into(), true),
         };
 
-        let raw_entry = format!("{} → {} {}", key, label, flags);
+        let raw_entry = format!("{key} → {label} {flags}");
         let raw_entry_width = raw_entry.chars().count() as u16;
 
         let mut spacing = " ".to_string();
@@ -74,7 +74,7 @@ impl Entry {
 
     pub fn to_tty(&self, tty: &mut std::fs::File) -> std::io::Result<()> {
         for part in &self.styled_parts {
-            write!(tty, "{}", part)?;
+            write!(tty, "{part}")?;
         }
         Ok(())
     }

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -203,14 +203,11 @@ impl Panel {
         // Top border
         if !matches!(self.config.layout.border_type, BorderType::None) {
             let top = format!(
-                "{tl}{line}{tr}",
-                line = horizontal_line,
-                tl = top_left,
-                tr = top_right,
+                "{top_left}{horizontal_line}{top_right}",
             )
             .with(self.theme.accent.into())
             .on(self.theme.background.into());
-            write!(tty, "{}", top)?;
+            write!(tty, "{top}")?;
         }
 
         // Vertical sides
@@ -224,7 +221,7 @@ impl Panel {
             )
             .with(self.theme.accent.into())
             .on(self.theme.background.into());
-            write!(tty, "{}", line)?;
+            write!(tty, "{line}")?;
         }
 
         // Bottom border
@@ -234,14 +231,11 @@ impl Panel {
         ) {
             tty.queue(cursor::MoveTo(area.x, area.y + area.height))?;
             let bottom = format!(
-                "{bl}{line}{br}",
-                line = horizontal_line,
-                bl = bottom_left,
-                br = bottom_right
+                "{bottom_left}{horizontal_line}{bottom_right}"
             )
             .with(self.theme.accent.into())
             .on(self.theme.background.into());
-            write!(tty, "{}", bottom)?;
+            write!(tty, "{bottom}")?;
         }
 
         tty.flush()?;
@@ -295,7 +289,7 @@ impl Panel {
             .on(self.theme.background.into());
         let center_x = area.x + (area.width.saturating_sub(help_text.chars().count() as u16)) / 2;
         tty.queue(cursor::MoveTo(center_x, area.y))?;
-        write!(tty, "{}", styled_help_text)?;
+        write!(tty, "{styled_help_text}")?;
 
         tty.queue(cursor::MoveTo(area.x, area.y))?;
         let arrow = self
@@ -306,12 +300,12 @@ impl Panel {
             .to_string()
             .with(self.theme.text_secondary.into())
             .on(self.theme.background.into());
-        write!(tty, "{}", arrow)?;
+        write!(tty, "{arrow}")?;
         let sequence_text = sequence
             .to_string()
             .with(self.theme.text_primary.into())
             .on(self.theme.background.into());
-        write!(tty, "{}", sequence_text)?;
+        write!(tty, "{sequence_text}")?;
 
         Ok(())
     }

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -202,11 +202,9 @@ impl Panel {
 
         // Top border
         if !matches!(self.config.layout.border_type, BorderType::None) {
-            let top = format!(
-                "{top_left}{horizontal_line}{top_right}",
-            )
-            .with(self.theme.accent.into())
-            .on(self.theme.background.into());
+            let top = format!("{top_left}{horizontal_line}{top_right}",)
+                .with(self.theme.accent.into())
+                .on(self.theme.background.into());
             write!(tty, "{top}")?;
         }
 
@@ -230,11 +228,9 @@ impl Panel {
             BorderType::Rounded | BorderType::Square
         ) {
             tty.queue(cursor::MoveTo(area.x, area.y + area.height))?;
-            let bottom = format!(
-                "{bottom_left}{horizontal_line}{bottom_right}"
-            )
-            .with(self.theme.accent.into())
-            .on(self.theme.background.into());
+            let bottom = format!("{bottom_left}{horizontal_line}{bottom_right}")
+                .with(self.theme.accent.into())
+                .on(self.theme.background.into());
             write!(tty, "{bottom}")?;
         }
 

--- a/src/ui/panel.rs
+++ b/src/ui/panel.rs
@@ -247,9 +247,7 @@ impl Panel {
         sequence: &str,
         keys: &Vec<String>,
     ) -> std::io::Result<()> {
-        let mut line = area.y;
-
-        for key in keys {
+        for (line, key) in (area.y..).zip(keys) {
             if line >= area.y + area.height {
                 break; // stop if no more vertical space
             }
@@ -266,8 +264,6 @@ impl Panel {
                 &self.theme,
             );
             stylized_entry.to_tty(tty)?;
-
-            line += 1;
         }
 
         Ok(())


### PR DESCRIPTION
This updates both the cargo dependencies and the github actions to the latest releases.
It fixes a few linter issues that appear now on the latest toolchain.
There is now a release dry-run workflow to test the build and github release using a test tag and a draft release.
Finally, it sets up a dependabot config to simplify maintaining this crate in the future by keeping the dependencies up to date automatically.